### PR TITLE
Fixed Composer PSR-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "minimum-stability": "stable",
     "autoload": {
-        "PSR-4": {
+        "psr-4": {
             "iPublications\\": "iPublications/"
         }
     }


### PR DESCRIPTION
psr-4 stond verkeerd geschreven (ucase), daardoor ging het laden niet goed op osx en andere case sensitive os'en